### PR TITLE
Use numba for histograms

### DIFF
--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "- matplotlib\n",
     "- numpy\n",
-    "- scipy\n",
+    "- numba\n",
     "- pint"
    ]
   }

--- a/docs/plotting.ipynb
+++ b/docs/plotting.ipynb
@@ -634,18 +634,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To control the grid resolution, use the `resolution` keyword argument."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "osyris.map({\"data\": data[\"hydro\"][\"density\"], \"norm\": \"log\"},\n",
-    "           dx=dx, dz=dz, origin=center, direction=\"z\",\n",
-    "           resolution={'z': 512})"
+    "To control the grid resolution, use e.g. `resolution={'z': 512}`."
    ]
   }
  ],

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 matplotlib
 numba
 numpy
-scipy
 sphinx
 nbsphinx
 jupyter

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     matplotlib
     numba
     numpy
-    scipy
     pint
 
 [options.packages.find]

--- a/src/osyris/plot/histogram2d.py
+++ b/src/osyris/plot/histogram2d.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 from ..core import Array, Plot
-from .. import units
 from .render import render
 from ..core.tools import to_bin_centers, finmin, finmax
 from .parser import parse_layer

--- a/src/osyris/plot/utils.py
+++ b/src/osyris/plot/utils.py
@@ -54,19 +54,10 @@ def evaluate_on_grid(cell_positions_in_new_basis, cell_positions_in_original_bas
 
 
 @njit(parallel=True)
-def hist2d(x, y, values, xmin, xmax, nx, ymin, ymax, ny, logx, logy):
-    if logx:
-        xmin = np.log10(xmin)
-        xmax = np.log10(xmax)
-        x = np.log10(x)
-    if logy:
-        ymin = np.log10(ymin)
-        ymax = np.log10(ymax)
-        y = np.log10(y)
+def hist2d(x, y, values, xmin, xmax, nx, ymin, ymax, ny):
 
     out = np.zeros(shape=(values.shape[0], ny, nx), dtype=np.float64)
     counts = np.zeros(shape=(ny, nx), dtype=np.int64)
-
     dx = (xmax - xmin) / nx
     dy = (ymax - ymin) / ny
 
@@ -77,6 +68,4 @@ def hist2d(x, y, values, xmin, xmax, nx, ymin, ymax, ny, logx, logy):
             out[:, indy, indx] += values[:, i]
             counts[indy, indx] += 1
 
-    out /= counts
-
-    return out
+    return out, counts

--- a/src/osyris/plot/utils.py
+++ b/src/osyris/plot/utils.py
@@ -51,3 +51,32 @@ def evaluate_on_grid(cell_positions_in_new_basis, cell_positions_in_original_bas
                         out[:, k, j, i] = cell_values[:, n]
 
     return out
+
+
+@njit(parallel=True)
+def hist2d(x, y, values, xmin, xmax, nx, ymin, ymax, ny, logx, logy):
+    if logx:
+        xmin = np.log10(xmin)
+        xmax = np.log10(xmax)
+        x = np.log10(x)
+    if logy:
+        ymin = np.log10(ymin)
+        ymax = np.log10(ymax)
+        y = np.log10(y)
+
+    out = np.zeros(shape=(values.shape[0], ny, nx), dtype=np.float64)
+    counts = np.zeros(shape=(ny, nx), dtype=np.int64)
+
+    dx = (xmax - xmin) / nx
+    dy = (ymax - ymin) / ny
+
+    for i in prange(len(x)):
+        indx = int((x[i] - xmin) / dx)
+        indy = int((y[i] - ymin) / dy)
+        if (indx >= 0) and (indx < nx) and (indy >= 0) and (indy < ny):
+            out[:, indy, indx] += values[:, i]
+            counts[indy, indx] += 1
+
+    out /= counts
+
+    return out


### PR DESCRIPTION
Use `numba` to perform the fast histogramming instead of `scipy`'s `binned_statistic_2d`.
We can now remove `scipy` from the dependency list (for now).

Depends on #51 