### PR TITLE
Revert slicing changes for vectors

### DIFF
--- a/docs/loading_data.ipynb
+++ b/docs/loading_data.ipynb
@@ -307,7 +307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "center = data['sink']['position'][0]\n",
+    "center = data['sink']['position'][0:1]\n",
     "dx = 200 * osyris.units('au')"
    ]
   },
@@ -353,7 +353,7 @@
     "osyris.map(data[\"hydro\"][\"density\"],\n",
     "           {\"data\": data[\"sink\"][\"position\"], \"mode\": \"scatter\", \"c\": \"white\",\n",
     "            \"s\": 20. * osyris.units(\"au\"), \"alpha\": 0.7},\n",
-    "           norm='log', direction=\"z\", origin=center)"
+    "           norm='log', direction=\"z\", origin=center[0])"
    ]
   }
  ],

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -43,13 +43,10 @@ class Array:
     #     return self._array
 
     def __getitem__(self, slice_):
-        out = self.__class__(values=self._array[slice_],
-                             unit=self._unit,
-                             parent=self._parent,
-                             name=self._name)
-        if isinstance(slice_, int) and self.ndim > 1:
-            return out.reshape(1, len(out))
-        return out
+        return self.__class__(values=self._array[slice_],
+                              unit=self._unit,
+                              parent=self._parent,
+                              name=self._name)
 
     def __len__(self):
         if self._array.shape:

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -339,7 +339,7 @@ def test_slicing():
 
 def test_slicing_vector():
     a = osyris.Array(values=np.arange(12.).reshape(4, 3), unit='m')
-    assert all(np.ravel(a[2] == osyris.Array(values=[[6., 7., 8.]], unit='m')))
-    assert a[2].shape == (1, 3)
+    assert all(np.ravel(a[2:3] == osyris.Array(values=[[6., 7., 8.]], unit='m')))
+    assert a[2:3].shape == (1, 3)
     assert all(
         np.ravel(a[:2] == osyris.Array(values=[[0., 1., 2.], [3., 4., 5.]], unit='m')))


### PR DESCRIPTION
Revert changes for preserving the second dimension when slicing vectors with a single index introduced in #78 