### PR TITLE
More flexible unit handling in sink particle reader

### DIFF
--- a/docs/configuration.ipynb
+++ b/docs/configuration.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "def additional_units(ureg):\n",
-    "    ureg.define('solar_mass = 1.9889e+33 * g = msun')\n",
+    "    ureg.define('solar_mass = 1.9889e+33 * g = M_sun = M_sol')\n",
     "    ureg.define('radiation_constant = 7.5659146e-015 * erg / cm^3 / K^4 = ar')"
    ]
   },
@@ -68,7 +68,7 @@
     "\n",
     "    # Mass\n",
     "    try:\n",
-    "        data[\"hydro\"][\"mass\"] = (data[\"hydro\"][\"density\"] * data[\"amr\"][\"dx\"]**3).to(\"msun\")\n",
+    "        data[\"hydro\"][\"mass\"] = (data[\"hydro\"][\"density\"] * data[\"amr\"][\"dx\"]**3).to(\"M_sun\")\n",
     "    except KeyError:\n",
     "        pass"
    ]

--- a/docs/data_structures.ipynb
+++ b/docs/data_structures.ipynb
@@ -379,7 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"hydro\"][\"mass\"].to(\"msun\")"
+    "data[\"hydro\"][\"mass\"].to(\"M_sun\")"
    ]
   },
   {
@@ -395,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"hydro\"][\"mass\"] = data[\"hydro\"][\"mass\"].to(\"msun\")"
+    "data[\"hydro\"][\"mass\"] = data[\"hydro\"][\"mass\"].to(\"M_sun\")"
    ]
   },
   {

--- a/docs/plotting_histograms.ipynb
+++ b/docs/plotting_histograms.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data[\"hydro\"][\"mass\"] = (data[\"hydro\"][\"density\"] * (data[\"amr\"][\"dx\"]**3)).to(\"msun\")\n",
+    "data[\"hydro\"][\"mass\"] = (data[\"hydro\"][\"density\"] * (data[\"amr\"][\"dx\"]**3)).to(\"M_sun\")\n",
     "osyris.histogram1d(data[\"hydro\"][\"density\"],\n",
     "                   weights=data[\"hydro\"][\"mass\"],\n",
     "                   logx=True)"

--- a/docs/plotting_maps.ipynb
+++ b/docs/plotting_maps.ipynb
@@ -467,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.sum(data[\"hydro\"][\"disk_density\"]*(data[\"amr\"][\"dx\"]**3)).to(\"msun\")"
+    "np.sum(data[\"hydro\"][\"disk_density\"]*(data[\"amr\"][\"dx\"]**3)).to(\"M_sun\")"
    ]
   },
   {

--- a/docs/plotting_particles.ipynb
+++ b/docs/plotting_particles.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data['part']['mass'] = data['part']['mass'].to('msun')\n",
+    "data['part']['mass'] = data['part']['mass'].to('M_sun')\n",
     "data"
    ]
   },

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -128,7 +128,7 @@ def additional_variables(data):
 
     # Mass
     try:
-        data['hydro']['mass'] = data['hydro']['density'] * data['amr']['dx']**3
-        data['hydro']['mass'].to('msun')
+        data['hydro']['mass'] = (data['hydro']['density'] *
+                                 data['amr']['dx']**3).to('M_sun')
     except KeyError:
         pass

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -99,7 +99,7 @@ def additional_units():
     Define additional useful ureg and constants
     """
     ureg.define('bolometric_luminosity = 3.0128e+28 * W = L_bol0')
-    ureg.define('solar_luminosity = 3.828e+26 * W = L_sun')
+    ureg.define('solar_luminosity = 3.828e+26 * W = L_sun = L_sol')
     ureg.define('earth_mass = 5.97216787e+27 * g = M_earth')
     ureg.define('jupiter_mass = 1.8981246e+30 * g = M_jup')
     ureg.define('solar_mass = 1.9889e+33 * g = M_sun = M_sol')

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -98,7 +98,14 @@ def additional_units():
     """
     Define additional useful ureg and constants
     """
-    ureg.define('solar_mass = 1.9889e+33 * g = msun')
+    ureg.define('bolometric_luminosity = 3.0128e+28 * W = L_bol0')
+    ureg.define('solar_luminosity = 3.828e+26 * W = L_sun')
+    ureg.define('earth_mass = 5.97216787e+27 * g = M_earth')
+    ureg.define('jupiter_mass = 1.8981246e+30 * g = M_jup')
+    ureg.define('solar_mass = 1.9889e+33 * g = M_sun = M_sol')
+    ureg.define('earth_radius = 6.3781e+08 * cm = R_earth')
+    ureg.define('jupiter_radius = 7.1492e+09 * cm = R_jup')
+    ureg.define('solar_radius = 6.957e+10 * cm = R_sun = R_sol')
     ureg.define('radiation_constant = 7.56591469318689378e-015 * erg / cm^3 / K^4 = ar')
 
 

--- a/src/osyris/io/sink.py
+++ b/src/osyris/io/sink.py
@@ -41,14 +41,18 @@ class SinkReader:
 
         # Parse units
         unit_list = []
+        m = meta['unit_d'] * meta['unit_l']**3 * units.g  # noqa: F841
+        l = meta['unit_l'] * units.cm  # noqa: F841, E741
+        t = meta['unit_t'] * units.s  # noqa: F841
         for u in unit_combinations:
-            m = meta['unit_d'] * meta['unit_l']**3 * units.g  # noqa: F841
-            l = meta['unit_l'] * units.cm  # noqa: F841, E741
-            t = meta['unit_t'] * units.s  # noqa: F841
-            if u.strip() == '1':
+            if u.strip().replace("[", "").replace("]", "") == '1':
                 unit_list.append(1.0 * units.dimensionless)
             else:
-                unit_list.append(eval(u.replace(' ', '*')))
+                if all(x in u for x in ["[", "]"]):
+                    # Legacy sink format quantities are not in code units
+                    unit_list.append(units(u.replace("[", "").replace("]", "")))
+                else:
+                    unit_list.append(eval(u.replace(' ', '*')))
 
         sink = Datagroup()
         for i, (key, unit) in enumerate(zip(key_list, unit_list)):


### PR DESCRIPTION
This is to allow loading outputs using the old ism sink format, which have been converted using the `ramses-ism-to-osyris` tool.

Note that this renames `msun` to `M_sum` or `M_sol`, which potentially breaks previous notebooks, as well as the config file (again!).