### PR TITLE
Fix grav group units

### DIFF
--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -64,6 +64,7 @@ def get_unit(string, ud, ul, ut):
         'grav_acceleration_y': acceleration,
         'grav_acceleration_z': acceleration,
         'grav_potential': energy,
+        'internal_energy': energy,
         'thermal_pressure': energy,
         'pressure': energy,
         'radiative_energy': energy,

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -63,6 +63,7 @@ def get_unit(string, ud, ul, ut):
         'grav_acceleration_x': acceleration,
         'grav_acceleration_y': acceleration,
         'grav_acceleration_z': acceleration,
+        'grav_potential': energy,
         'thermal_pressure': energy,
         'pressure': energy,
         'radiative_energy': energy,

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -63,7 +63,7 @@ def get_unit(string, ud, ul, ut):
         'grav_acceleration_x': acceleration,
         'grav_acceleration_y': acceleration,
         'grav_acceleration_z': acceleration,
-        'grav_potential': energy,
+        'grav_potential': velocity**2,
         'internal_energy': energy,
         'thermal_pressure': energy,
         'pressure': energy,

--- a/src/osyris/io/grav.py
+++ b/src/osyris/io/grav.py
@@ -19,9 +19,9 @@ class GravReader(Reader):
         if not os.path.exists(fname):
             return
         # Add gravity fields
-        descriptor = {"potential": "d"}
+        descriptor = {"grav_potential": "d"}
         for n in range(meta["ndim"]):
-            descriptor["acceleration_" + "xyz"[n]] = "d"
+            descriptor["grav_acceleration_" + "xyz"[n]] = "d"
 
         self.descriptor_to_variables(descriptor=descriptor, meta=meta, select=select)
         self.initialized = True


### PR DESCRIPTION
grav group was displaying dimensionless units since their strings weren't in the config file. 