### PR TITLE
Add support for slicing Arrays with other Arrays

### DIFF
--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -161,7 +161,7 @@
    "outputs": [],
    "source": [
     "ind = np.argmax(data[\"hydro\"][\"density\"])\n",
-    "center = data[\"amr\"][\"position\"][ind.values]\n",
+    "center = data[\"amr\"][\"position\"][ind]\n",
     "center"
    ]
   },

--- a/docs/data_structures.ipynb
+++ b/docs/data_structures.ipynb
@@ -303,7 +303,7 @@
    "outputs": [],
    "source": [
     "ind = np.argmax(data[\"hydro\"][\"density\"])\n",
-    "center = data[\"amr\"][\"position\"][ind.values]\n",
+    "center = data[\"amr\"][\"position\"][ind]\n",
     "center"
    ]
   },

--- a/docs/loading_data.ipynb
+++ b/docs/loading_data.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "osyris.map({\"data\": data[\"hydro\"][\"density\"], \"norm\": \"log\"},\n",
     "           dx=1000 * osyris.units('au'),\n",
-    "           origin=data[\"amr\"][\"position\"][np.argmax(data[\"hydro\"][\"density\"]).values],\n",
+    "           origin=data[\"amr\"][\"position\"][np.argmax(data[\"hydro\"][\"density\"])],\n",
     "           direction='z')"
    ]
   },
@@ -252,7 +252,7 @@
    "source": [
     "osyris.map({\"data\": data[\"hydro\"][\"density\"], \"norm\": \"log\"},\n",
     "           dx=2000 * osyris.units(\"au\"),\n",
-    "           origin=data[\"amr\"][\"position\"][np.argmax(data[\"hydro\"][\"density\"]).values],\n",
+    "           origin=data[\"amr\"][\"position\"][np.argmax(data[\"hydro\"][\"density\"])],\n",
     "           direction='z')"
    ]
   },

--- a/docs/plotting_maps.ipynb
+++ b/docs/plotting_maps.ipynb
@@ -27,7 +27,7 @@
     "path = \"osyrisdata/starformation\"\n",
     "data = osyris.Dataset(8, path=path).load()\n",
     "ind = np.argmax(data[\"hydro\"][\"density\"])\n",
-    "center = data[\"amr\"][\"position\"][ind.values]"
+    "center = data[\"amr\"][\"position\"][ind]"
    ]
   },
   {

--- a/docs/recipes.ipynb
+++ b/docs/recipes.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "# Find center\n",
     "ind = np.argmax(data8[\"hydro\"][\"density\"])\n",
-    "center = data8[\"amr\"][\"position\"][ind.values]\n",
+    "center = data8[\"amr\"][\"position\"][ind]\n",
     "\n",
     "dx = 2000 * osyris.units(\"au\")\n",
     "# Extract density slices by copying data into structures\n",

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -27,7 +27,6 @@ def _binary_op(op, lhs, rhs, strict=True, **kwargs):
 
 
 class Array(Base):
-
     def __init__(self, values, unit=None, parent=None, name=""):
 
         if isinstance(values, Base):
@@ -53,6 +52,9 @@ class Array(Base):
             if not isinstance(slice_, self.__class__):
                 raise ValueError(
                     "Cannot slice using a Vector, only Array is supported.")
+            if slice_.dtype not in ('int32', 'int64', bool):
+                raise TypeError(
+                    "Dtype of the Array must be integer or bool for slicing.")
             slice_ = slice_.values
         return self.__class__(values=self._array[slice_],
                               unit=self.unit,

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -49,7 +49,10 @@ class Array(Base):
         self.name = name
 
     def __getitem__(self, slice_):
-        if isinstance(slice_, self.__class__):
+        if isinstance(slice_, Base):
+            if not isinstance(slice_, self.__class__):
+                raise ValueError(
+                    "Cannot slice using a Vector, only Array is supported.")
             slice_ = slice_.values
         return self.__class__(values=self._array[slice_],
                               unit=self.unit,

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -27,6 +27,7 @@ def _binary_op(op, lhs, rhs, strict=True, **kwargs):
 
 
 class Array(Base):
+
     def __init__(self, values, unit=None, parent=None, name=""):
 
         if isinstance(values, Base):
@@ -48,6 +49,8 @@ class Array(Base):
         self.name = name
 
     def __getitem__(self, slice_):
+        if isinstance(slice_, self.__class__):
+            slice_ = slice_.values
         return self.__class__(values=self._array[slice_],
                               unit=self.unit,
                               parent=self.parent,

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -21,6 +21,7 @@ def _binary_op(op, lhs, rhs):
 
 
 class Vector(Base):
+
     def __init__(self, x, y=None, z=None, parent=None, name="", unit=None):
 
         if isinstance(x, Array):
@@ -58,6 +59,8 @@ class Vector(Base):
         return out
 
     def __getitem__(self, slice_):
+        if isinstance(slice_, Array):
+            slice_ = slice_.values
         return self.__class__(**{c: xyz[slice_]
                                  for c, xyz in self._xyz.items()},
                               parent=self.parent,

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -21,7 +21,6 @@ def _binary_op(op, lhs, rhs):
 
 
 class Vector(Base):
-
     def __init__(self, x, y=None, z=None, parent=None, name="", unit=None):
 
         if isinstance(x, Array):
@@ -59,10 +58,6 @@ class Vector(Base):
         return out
 
     def __getitem__(self, slice_):
-        if isinstance(slice_, self.__class__):
-            raise ValueError("Cannot slice using a Vector, only Array is supported.")
-        if isinstance(slice_, Array):
-            slice_ = slice_.values
         return self.__class__(**{c: xyz[slice_]
                                  for c, xyz in self._xyz.items()},
                               parent=self.parent,

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -59,6 +59,8 @@ class Vector(Base):
         return out
 
     def __getitem__(self, slice_):
+        if isinstance(slice_, self.__class__):
+            raise ValueError("Cannot slice using a Vector, only Array is supported.")
         if isinstance(slice_, Array):
             slice_ = slice_.values
         return self.__class__(**{c: xyz[slice_]

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -668,6 +668,14 @@ def test_slicing_with_array():
     a = Array(values=[1., 2., 3., 4., 5.], unit='m')
     select = a > (3. * units('m'))
     assert arrayequal(a[select], Array(values=[4., 5.], unit='m'))
+    b = Array(values=[0, 2, 4])
+    assert arrayequal(a[b], Array(values=[1., 3., 5.], unit='m'))
+
+
+def test_slicing_with_array_bad_dtype():
+    a = Array(values=[1., 2., 3., 4., 5.], unit='m')
+    with pytest.raises(TypeError):
+        _ = a[Array(values=[0., 2., 4.])]
 
 
 def test_copy():

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -62,6 +62,15 @@ def test_constructor_masked_array():
     assert np.array_equal(array.values.mask, [False, False, False, True, True])
 
 
+def test_constructor_2d():
+    a = np.arange(12.).reshape(4, 3)
+    array = Array(values=a, unit='m')
+    assert array.unit == units('m')
+    assert len(array) == len(a)
+    assert array.shape == a.shape
+    assert np.array_equal(array.values, a)
+
+
 def test_addition():
     a = Array(values=[1., 2., 3., 4., 5.], unit='m')
     b = Array(values=[6., 7., 8., 9., 10.], unit='m')
@@ -636,22 +645,29 @@ def test_max():
 def test_reshape():
     a = Array(values=[1., 2., 3., 4., 5., 6.], unit='m')
     expected = Array(values=[[1., 2., 3.], [4., 5., 6.]], unit='m')
-    assert arraytrue(np.ravel(a.reshape(2, 3) == expected))
+    assert arrayequal(a.reshape(2, 3), expected)
 
 
 def test_slicing():
     a = Array(values=[11., 12., 13., 14., 15.], unit='m')
     assert a[2] == Array(values=[13.], unit='m')
-    assert arraytrue(a[:4] == Array(values=[11., 12., 13., 14.], unit='m'))
-    assert arraytrue(a[2:4] == Array(values=[13., 14.], unit='m'))
+    assert arrayequal(a[:4], Array(values=[11., 12., 13., 14.], unit='m'))
+    assert arrayequal(a[2:4], Array(values=[13., 14.], unit='m'))
 
 
-def test_slicing_vector():
+def test_slicing_2d():
     a = Array(values=np.arange(12.).reshape(4, 3), unit='m')
-    assert arraytrue(np.ravel(a[2:3] == Array(values=[[6., 7., 8.]], unit='m')))
+    assert arrayequal(a[0, :], Array(values=[0., 1., 2.], unit='m'))
+    assert arrayequal(a[1], Array(values=[3., 4., 5.], unit='m'))
+    assert arrayequal(a[2:3], Array(values=[[6., 7., 8.]], unit='m'))
     assert a[2:3].shape == (1, 3)
-    assert arraytrue(
-        np.ravel(a[:2] == Array(values=[[0., 1., 2.], [3., 4., 5.]], unit='m')))
+    assert arrayequal(a[:2], Array(values=[[0., 1., 2.], [3., 4., 5.]], unit='m'))
+
+
+def test_slicing_with_array():
+    a = Array(values=[1., 2., 3., 4., 5.], unit='m')
+    select = a > (3. * units('m'))
+    assert arrayequal(a[select], Array(values=[4., 5.], unit='m'))
 
 
 def test_copy():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -719,13 +719,21 @@ def test_slicing_with_array():
     z = Array(values=[11., 12., 13., 14., 15.], unit='m')
     v = Vector(x, y, z)
     select = v.norm > (15. * units('m'))
-
-    exp_x = Array(values=[1., 2., 3., 4., 5.], unit='m')
-    exp_y = Array(values=[6., 7., 8., 9., 10.], unit='m')
-    exp_z = Array(values=[11., 12., 13., 14., 15.], unit='m')
+    exp_x = Array(values=[3., 4., 5.], unit='m')
+    exp_y = Array(values=[8., 9., 10.], unit='m')
+    exp_z = Array(values=[13., 14., 15.], unit='m')
     expected = Vector(exp_x, exp_y, exp_z)
+    assert vectorequal(v[select], expected)
 
-    assert arrayequal(v[select], Array(values=[4., 5.], unit='m'))
+
+def test_slicing_with_vector_raises():
+    x = Array(values=[1., 2., 3., 4., 5.], unit='m')
+    y = Array(values=[6., 7., 8., 9., 10.], unit='m')
+    z = Array(values=[11., 12., 13., 14., 15.], unit='m')
+    v = Vector(x, y, z)
+    select = v > (16. * units('m'))
+    with pytest.raises(ValueError):
+        _ = v[select]
 
 
 def test_copy():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -713,6 +713,21 @@ def test_slicing():
     assert vectorequal(v[2:4], Vector(x=x[2:4], y=y[2:4], z=z[2:4]))
 
 
+def test_slicing_with_array():
+    x = Array(values=[1., 2., 3., 4., 5.], unit='m')
+    y = Array(values=[6., 7., 8., 9., 10.], unit='m')
+    z = Array(values=[11., 12., 13., 14., 15.], unit='m')
+    v = Vector(x, y, z)
+    select = v.norm > (15. * units('m'))
+
+    exp_x = Array(values=[1., 2., 3., 4., 5.], unit='m')
+    exp_y = Array(values=[6., 7., 8., 9., 10.], unit='m')
+    exp_z = Array(values=[11., 12., 13., 14., 15.], unit='m')
+    expected = Vector(exp_x, exp_y, exp_z)
+
+    assert arrayequal(v[select], Array(values=[4., 5.], unit='m'))
+
+
 def test_copy():
     x = Array(values=[1., 2., 3., 4., 5.], unit='m')
     y = Array(values=[6., 7., 8., 9., 10.], unit='m')


### PR DESCRIPTION
Since #98 , comparison operators `>, <, >=, <=, ==, !=` return Arrays instead of numpy.ndarray.
This PR add the possibility to use Arrays to slice other Arrays.
This is useful when performing a boolean selection, for instance.
```Py
select = data["hydro"]["density"] > (1.0e-15 * units('g / cm**3'))
subset = data["hydro"][select]
```

We prevent using a `Vector` for slicing, as this makes no sense.
We also only allow slicing with Arrays that have dtype `int` or `bool`.