### PR TITLE
Fix multigroup FLD radiative_energy units

### DIFF
--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -22,7 +22,7 @@ def configure_constants(units):
         'radiation_constant = 7.56591469318689378e-015 * erg / cm^3 / K^4 = ar')
 
 
-def configure_units(units, data):
+def configure_units(data, units):
 
     unit_d = data.meta['unit_d']
     unit_l = data.meta['unit_l']

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -107,6 +107,7 @@ def additional_variables(data):
     """
     Here are some additional variables that are to be computed every time data
     is loaded.
+
     It is recommended to place your variables in a `try/except` block, which
     will prevent errors if the variables are not found, for instance when
     loading data from a different simulation.

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -22,11 +22,7 @@ def configure_constants(units):
         'radiation_constant = 7.56591469318689378e-015 * erg / cm^3 / K^4 = ar')
 
 
-def configure_units(data, units):
-
-    unit_d = data.meta['unit_d']
-    unit_l = data.meta['unit_l']
-    unit_t = data.meta["unit_t"]
+def configure_units(units, unit_d, unit_l, unit_t):
 
     density = unit_d * units("g / cm**3")
     velocity = (unit_l / unit_t) * units("cm / s")
@@ -102,11 +98,7 @@ def configure_units(data, units):
         'temperature': temperature
     })
 
-    if "ngrp" in data.meta:
-        library.update({
-            "radiative_energy_{}".format(i): energy
-            for i in range(1, data.meta["ngrp"] + 1)
-        })
+    library.update({"radiative_energy_{}".format(i): energy for i in range(1, 31)})
 
     return library
 
@@ -115,7 +107,6 @@ def additional_variables(data):
     """
     Here are some additional variables that are to be computed every time data
     is loaded.
-
     It is recommended to place your variables in a `try/except` block, which
     will prevent errors if the variables are not found, for instance when
     loading data from a different simulation.

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -22,7 +22,11 @@ def configure_constants(units):
         'radiation_constant = 7.56591469318689378e-015 * erg / cm^3 / K^4 = ar')
 
 
-def configure_units(units, unit_d, unit_l, unit_t):
+def configure_units(units, data):
+
+    unit_d = data.meta['unit_d']
+    unit_l = data.meta['unit_l']
+    unit_t = data.meta["unit_t"]
 
     density = unit_d * units("g / cm**3")
     velocity = (unit_l / unit_t) * units("cm / s")
@@ -81,7 +85,6 @@ def configure_units(units, unit_d, unit_l, unit_t):
         'thermal_pressure': energy,
         'pressure': energy,
         'radiative_energy': energy,
-        'radiative_energy_1': energy,
         'time': time,
         'length': length,
         'x': length,
@@ -98,6 +101,13 @@ def configure_units(units, unit_d, unit_l, unit_t):
         'mass': mass,
         'temperature': temperature
     })
+
+    if "ngrp" in data.meta:
+        library.update({
+            "radiative_energy_{}".format(i): energy
+            for i in range(1, data.meta["ngrp"] + 1)
+        })
+
     return library
 
 

--- a/src/osyris/core/dataset.py
+++ b/src/osyris/core/dataset.py
@@ -111,7 +111,4 @@ class Dataset:
             self[key] = value
 
     def set_units(self):
-        self.units = config.configure_units(units=units,
-                                            unit_d=self.meta['unit_d'],
-                                            unit_l=self.meta['unit_l'],
-                                            unit_t=self.meta['unit_t'])
+        self.units = config.configure_units(self, units=units)

--- a/src/osyris/core/dataset.py
+++ b/src/osyris/core/dataset.py
@@ -111,4 +111,7 @@ class Dataset:
             self[key] = value
 
     def set_units(self):
-        self.units = config.configure_units(self, units=units)
+        self.units = config.configure_units(units=units,
+                                            unit_d=self.meta['unit_d'],
+                                            unit_l=self.meta['unit_l'],
+                                            unit_t=self.meta['unit_t'])


### PR DESCRIPTION
Previous config file would only configure the units of the first radiative group, which works fine for grey simulations but doesn't load properly the next groups in multigroup simulations.

Added 30 "radiative_energy_{}" to the library in the config file.