### PR TITLE
Rasterize pcolormesh by default so that it looks ok in pdf figures

### DIFF
--- a/src/osyris/plot/wrappers.py
+++ b/src/osyris/plot/wrappers.py
@@ -60,7 +60,7 @@ def pcolormesh(ax, x, y, z, cbar=False, cblabel=None, zorder=1, **kwargs):
     """
     Wrapper around Matplotlib's pcolormesh plot.
     """
-    default_args = {"shading": "nearest", "zorder": zorder}
+    default_args = {"shading": "nearest", "zorder": zorder, "rasterized": True}
     default_args.update(kwargs)
     out = ax.pcolormesh(x, y, z, **default_args)
     if cbar:


### PR DESCRIPTION
When saving maps to pdf, (`osyris.map(..., filename='test.pdf'`), the grid of the mesh pixels was visible. We now rasterize the mesh (also speeds up rending in notebook for large maps).

Left: before, Right: after
![Screenshot at 2022-09-29 16-48-12](https://user-images.githubusercontent.com/39047984/193064512-c6da51ad-1213-439f-bca7-8c9a6ce2a8e5.png)
