### PR TITLE
Fix pint import error

### DIFF
--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
-from pint.quantity import Quantity
+from pint import Quantity
 from pint.errors import DimensionalityError
 from .base import Base
 from .tools import value_to_string

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
-from pint.quantity import Quantity
+from pint import Quantity
 from .base import Base
 from .array import Array
 from .tools import value_to_string

--- a/src/osyris/plot/histogram2d.py
+++ b/src/osyris/plot/histogram2d.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
-from pint.quantity import Quantity
+from pint import Quantity
 from typing import Union
 from ..core import Array, Plot
 from .render import render

--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import numpy.ma as ma
-from pint.quantity import Quantity
+from pint import Quantity
 from typing import Union
 from .direction import get_direction
 from .render import render

--- a/src/osyris/plot/scatter.py
+++ b/src/osyris/plot/scatter.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from pint.quantity import Quantity
+from pint import Quantity
 from ..core import Plot, Array
 from .. import units
 from .render import render

--- a/src/osyris/plot/wrappers.py
+++ b/src/osyris/plot/wrappers.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PatchCollection
 import numpy as np
-from pint.quantity import Quantity
+from pint import Quantity
 
 
 def _add_colorbar(obj, ax, cax=None, label=None):


### PR DESCRIPTION
As of release 0.20 of pint, there no longer is a `pint.quantity` attribute to the module. This creates import errors when initializing osyris, as the `Quantity` class is imported using `from pint.quantity import Quantity`
Changing the line to `from pint import Quantity` fixes the issue.
There are no backward compatibility issues either when committing this change.