### PR TITLE
Expanding "operation" keyword

### DIFF
--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -130,9 +130,9 @@ def map(*layers,
         the following syntax should be used: ``resolution={'x': 128, 'y': 192}``.
         Default is ``256``.
 
-    :param operation: The operation to apply along the ``z`` dimension if ``dz`` is
-        not ``None``. Possible values are ``'sum'``, ``'nansum'``,
-         ``'mean'``, ``'min'``, and ``'max'``. Default is ``'sum'``.
+    :param operation: Numpy operation to apply along the ``z`` dimension if ``dz`` is
+        not ``None``. Example values are ``'sum'``, ``'nansum'``, ``'nanmin'``,
+        ``'nanmax'`` ``'mean'``, ``'min'``, and ``'max'``. Default is ``'sum'``.
 
     :param ax: A matplotlib axes inside which the figure will be plotted.
         Default is ``None``, in which case some new axes a created.

--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -131,8 +131,8 @@ def map(*layers,
         Default is ``256``.
 
     :param operation: The operation to apply along the ``z`` dimension if ``dz`` is
-        not ``None``. Possible values are ``'sum'``, ``'mean'``, ``'min'``, and
-        ``'max'``. Default is ``'sum'``.
+        not ``None``. Possible values are ``'sum'``, ``'nansum'``,
+         ``'mean'``, ``'min'``, and ``'max'``. Default is ``'sum'``.
 
     :param ax: A matplotlib axes inside which the figure will be plotted.
         Default is ``None``, in which case some new axes a created.

--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -132,7 +132,8 @@ def map(*layers,
 
     :param operation: Numpy operation to apply along the ``z`` dimension if ``dz`` is
         not ``None``. Example values are ``'sum'``, ``'nansum'``, ``'nanmin'``,
-        ``'nanmax'`` ``'mean'``, ``'min'``, and ``'max'``. Default is ``'sum'``.
+        ``'nanmax'``, ``'nanmean'``, ``'mean'``, ``'min'``, and ``'max'``.
+        Default is ``'sum'``.
 
     :param ax: A matplotlib axes inside which the figure will be plotted.
         Default is ``None``, in which case some new axes a created.

--- a/src/osyris/plot/wrappers.py
+++ b/src/osyris/plot/wrappers.py
@@ -41,7 +41,7 @@ def quiver(ax,
     default_args = {"angles": "xy", "pivot": "mid", "zorder": zorder}
     default_args.update(kwargs)
 
-    skips = np.around(np.array(z.shape) * 4.0 / 128.0 / density).astype(np.int)
+    skips = np.around(np.array(z.shape) * 4.0 / 128.0 / density).astype(np.int_)
     skip = (slice(None, None, skips[0]), slice(None, None, skips[1]))
 
     args = [x[skip[0]], y[skip[1]], z[..., 0][skip], z[..., 1][skip]]


### PR DESCRIPTION
This allows the user to call any numpy operation when performing thick maps. It is particularly useful in star formation when doing column densities of cells belonging to the disk only, as it requires us to call `nansum` instead of `sum` since the non-disk cells are masked. Below is an example of this:

![mach_1p0_column_density_vis_01858](https://github.com/osyris-project/osyris/assets/60321972/0f0500d4-8db9-4917-afc6-0da0405df97a)
