### PR TITLE
Add `__version__` to package and use isort

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,13 +25,16 @@ jobs:
       run: |
         which python
         python -m pip install --upgrade pip
-        python -m pip install flake8==7.0.0 black[jupyter]==24.3.0
+        python -m pip install flake8==7.0.0 black[jupyter]==24.3.0 isort==5.13.2
     - name: Check black formatting
       run: |
         black --check .
     - name: Lint with flake8
       run: |
         flake8 . --count --statistics
+    - name: Check imports with isort
+      run: |
+        isort --check .
 
   tests:
     needs: formatting

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 from .config import config
+from .units import units  # isort:skip
 from .core import Array, Datagroup, Dataset, Plot, Vector
 from .plot import histogram1d, histogram2d, map, plot, scatter
 from .spatial import extract_box, extract_sphere
-from .units import units
 
 try:
     __version__ = importlib.metadata.version(__package__ or __name__)

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
+""" Osyris: A Python package for the analysis of astrophysical simulations
+
+   isort:skip_file
+"""
+
 import importlib.metadata
 
 from .config import config
-from .units import units  # isort:skip
+from .units import units
 from .core import Array, Datagroup, Dataset, Plot, Vector
 from .plot import histogram1d, histogram2d, map, plot, scatter
 from .spatial import extract_box, extract_sphere

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -15,3 +15,20 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
 del importlib
+
+__all__ = [
+    "Array",
+    "Datagroup",
+    "Dataset",
+    "Plot",
+    "Vector",
+    "config",
+    "units",
+    "histogram1d",
+    "histogram2d",
+    "scatter",
+    "map",
+    "plot",
+    "extract_box",
+    "extract_sphere",
+]

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
+import importlib.metadata
 
 from .config import config
 from .units import units
 from .core import Array, Datagroup, Dataset, Plot, Vector
 from .plot import histogram1d, histogram2d, scatter, map, plot
 from .spatial import extract_box, extract_sphere
+
+try:
+    __version__ = importlib.metadata.version(__package__ or __name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"
+
+del importlib

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -4,10 +4,10 @@
 import importlib.metadata
 
 from .config import config
-from .units import units
 from .core import Array, Datagroup, Dataset, Plot, Vector
-from .plot import histogram1d, histogram2d, scatter, map, plot
+from .plot import histogram1d, histogram2d, map, plot, scatter
 from .spatial import extract_box, extract_sphere
+from .units import units
 
 try:
     __version__ = importlib.metadata.version(__package__ or __name__)

--- a/src/osyris/config/__init__.py
+++ b/src/osyris/config/__init__.py
@@ -7,6 +7,7 @@
 import os
 import sys
 from shutil import copyfile
+
 from . import defaults as default_config
 
 user_config_dir = os.path.join(os.path.expanduser("~"), ".osyris")

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -4,7 +4,7 @@
 Define default values so that you don't have to specify them every time.
 """
 
-from math import sqrt, pi
+from math import pi, sqrt
 
 
 def configure_constants(units):

--- a/src/osyris/core/__init__.py
+++ b/src/osyris/core/__init__.py
@@ -4,7 +4,7 @@
 # flake8: noqa
 
 from .array import Array
+from .vector import Vector  # isort:skip
 from .datagroup import Datagroup
 from .dataset import Dataset
 from .plot import Plot
-from .vector import Vector

--- a/src/osyris/core/__init__.py
+++ b/src/osyris/core/__init__.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
+""" Core data structures of Osyris
+
+   isort:skip_file
+"""
 
 from .array import Array
-from .vector import Vector  # isort:skip
+from .vector import Vector
 from .datagroup import Datagroup
 from .dataset import Dataset
 from .plot import Plot
+
+__all__ = ["Array", "Vector", "Datagroup", "Dataset", "Plot"]

--- a/src/osyris/core/__init__.py
+++ b/src/osyris/core/__init__.py
@@ -4,7 +4,7 @@
 # flake8: noqa
 
 from .array import Array
-from .vector import Vector
 from .datagroup import Datagroup
 from .dataset import Dataset
 from .plot import Plot
+from .vector import Vector

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -3,9 +3,10 @@
 import numpy as np
 from pint import Quantity
 from pint.errors import DimensionalityError
+
+from .. import units
 from .base import Base
 from .tools import value_to_string
-from .. import units
 
 APPLY_OP_TO_UNIT = ("multiply", "true_divide", "divide", "sqrt", "power", "reciprocal")
 

--- a/src/osyris/core/base.py
+++ b/src/osyris/core/base.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from .tools import make_label
 import numpy as np
+
+from .tools import make_label
 
 
 class Base:

--- a/src/osyris/core/datagroup.py
+++ b/src/osyris/core/datagroup.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
+
 from .tools import bytes_to_human_readable
 
 

--- a/src/osyris/core/dataset.py
+++ b/src/osyris/core/dataset.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-import numpy as np
 from copy import copy, deepcopy
+
+import numpy as np
+
 from .. import config
 from ..io import Loader
+from ..units import UnitsLibrary, units
 from .datagroup import Datagroup
 from .tools import bytes_to_human_readable
-from ..units import units, UnitsLibrary
 
 
 class Dataset:

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 from pint import Quantity
-from .base import Base
+
 from .array import Array
+from .base import Base
 from .tools import value_to_string
 
 

--- a/src/osyris/io/__init__.py
+++ b/src/osyris/io/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
-
 from . import utils
 from .loader import Loader
+
+__all__ = ["utils", "Loader"]

--- a/src/osyris/io/__init__.py
+++ b/src/osyris/io/__init__.py
@@ -3,5 +3,5 @@
 
 # flake8: noqa
 
-from .loader import Loader
 from . import utils
+from .loader import Loader

--- a/src/osyris/io/amr.py
+++ b/src/osyris/io/amr.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
+
+from . import utils
 from .hilbert import hilbert_cpu_list
 from .reader import Reader, ReaderKind
-from . import utils
 
 
 class AmrReader(Reader):

--- a/src/osyris/io/grav.py
+++ b/src/osyris/io/grav.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 import os
-from .reader import Reader, ReaderKind
+
 from . import utils
+from .reader import Reader, ReaderKind
 
 
 class GravReader(Reader):

--- a/src/osyris/io/hilbert.py
+++ b/src/osyris/io/hilbert.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
+
 from ..core import Array
 
 

--- a/src/osyris/io/hydro.py
+++ b/src/osyris/io/hydro.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-import numpy as np
 import os
-from .reader import Reader, ReaderKind
+
+import numpy as np
+
 from . import utils
+from .reader import Reader, ReaderKind
 
 
 class HydroReader(Reader):

--- a/src/osyris/io/loader.py
+++ b/src/osyris/io/loader.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-import numpy as np
 import os
+
+import numpy as np
+
+from ..core import Array, Datagroup
 from . import utils
-from ..core import Datagroup, Array
 from .amr import AmrReader
 from .grav import GravReader
 from .hydro import HydroReader
 from .part import PartReader
+from .reader import ReaderKind
 from .rt import RtReader
 from .sink import SinkReader
-from .reader import ReaderKind
 
 
 class Loader:

--- a/src/osyris/io/part.py
+++ b/src/osyris/io/part.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-import numpy as np
 import os
-from .reader import Reader, ReaderKind
+
+import numpy as np
+
 from ..core import Array
 from . import utils
+from .reader import Reader, ReaderKind
 
 
 class PartReader(Reader):

--- a/src/osyris/io/reader.py
+++ b/src/osyris/io/reader.py
@@ -2,9 +2,11 @@
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from enum import Enum
+
 import numpy as np
-from . import utils
+
 from ..core import Array
+from . import utils
 
 
 class ReaderKind(Enum):

--- a/src/osyris/io/rt.py
+++ b/src/osyris/io/rt.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-import numpy as np
 import os
+
+import numpy as np
+
 from .reader import Reader, ReaderKind
 
 

--- a/src/osyris/io/sink.py
+++ b/src/osyris/io/sink.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-import numpy as np
 import os
-from ..core import Array, Datagroup
-from .reader import ReaderKind
+
+import numpy as np
+
 from .. import units as ureg
+from ..core import Array, Datagroup
 from . import utils
+from .reader import ReaderKind
 
 
 class SinkReader:

--- a/src/osyris/io/utils.py
+++ b/src/osyris/io/utils.py
@@ -4,7 +4,9 @@
 import glob
 import os
 import struct
+
 import numpy as np
+
 from ..core import Vector
 
 

--- a/src/osyris/plot/__init__.py
+++ b/src/osyris/plot/__init__.py
@@ -6,6 +6,6 @@
 from .histogram1d import histogram1d
 from .histogram2d import histogram2d
 from .map import map
-from .render import render
 from .plot import plot
+from .render import render
 from .scatter import scatter

--- a/src/osyris/plot/__init__.py
+++ b/src/osyris/plot/__init__.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
-
 from .histogram1d import histogram1d
 from .histogram2d import histogram2d
 from .map import map
 from .plot import plot
 from .render import render
 from .scatter import scatter
+
+__all__ = ["histogram1d", "histogram2d", "map", "plot", "render", "scatter"]

--- a/src/osyris/plot/direction.py
+++ b/src/osyris/plot/direction.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from ..core import Vector
-
 import numpy as np
+
+from ..core import Vector
 
 
 def _perpendicular_vector(v):

--- a/src/osyris/plot/histogram1d.py
+++ b/src/osyris/plot/histogram1d.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
+from typing import Iterable, Union
+
 import numpy as np
-from typing import Union, Iterable
-from ..core import Plot, Array
+
+from ..core import Array, Plot
+from ..core.tools import finmax, finmin, to_bin_centers
 from .render import render
-from ..core.tools import to_bin_centers, finmin, finmax
 
 
 def histogram1d(

--- a/src/osyris/plot/histogram2d.py
+++ b/src/osyris/plot/histogram2d.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
+from typing import Union
+
 import numpy as np
 from pint import Quantity
-from typing import Union
+
 from ..core import Array, Plot
-from .render import render
-from ..core.tools import to_bin_centers, finmin, finmax
+from ..core.tools import finmax, finmin, to_bin_centers
 from .parser import parse_layer
+from .render import render
 from .utils import hist2d
 
 

--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
+from typing import Union
+
 import numpy as np
 import numpy.ma as ma
 from pint import Quantity
-from typing import Union
+
+from ..core import Array, Plot, Vector
+from ..core.tools import apply_mask
 from .direction import get_direction
+from .parser import parse_layer
 from .render import render
 from .scatter import scatter
-from .parser import parse_layer
-from ..core import Plot, Array, Vector
-from ..core.tools import apply_mask
 from .utils import evaluate_on_grid
 
 

--- a/src/osyris/plot/plot.py
+++ b/src/osyris/plot/plot.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-import numpy as np
 from typing import Union
-from ..core import Plot, Array
+
+import numpy as np
+
+from ..core import Array, Plot
 from .render import render
 
 

--- a/src/osyris/plot/render.py
+++ b/src/osyris/plot/render.py
@@ -3,8 +3,8 @@
 
 import matplotlib.pyplot as plt
 
-from . import wrappers
 from ..core.tools import make_label
+from . import wrappers
 
 
 def render(x=None, y=None, data=None, logx=False, logy=False, ax=None):

--- a/src/osyris/plot/scatter.py
+++ b/src/osyris/plot/scatter.py
@@ -2,10 +2,11 @@
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from pint import Quantity
-from ..core import Plot, Array
+
 from .. import units
-from .render import render
+from ..core import Array, Plot
 from .parser import parse_layer
+from .render import render
 
 
 def scatter(

--- a/src/osyris/plot/wrappers.py
+++ b/src/osyris/plot/wrappers.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from ..core import Array
-from contextlib import redirect_stderr, nullcontext
 import io
+from contextlib import nullcontext, redirect_stderr
+
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PatchCollection
-import numpy as np
 from pint import Quantity
+
+from ..core import Array
 
 
 def _add_colorbar(obj, ax, cax=None, label=None):

--- a/src/osyris/spatial/__init__.py
+++ b/src/osyris/spatial/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
-
 from .subdomain import extract_box, extract_sphere
+
+__all__ = ["extract_box", "extract_sphere"]

--- a/src/osyris/spatial/__init__.py
+++ b/src/osyris/spatial/__init__.py
@@ -3,4 +3,4 @@
 
 # flake8: noqa
 
-from .subdomain import extract_sphere, extract_box
+from .subdomain import extract_box, extract_sphere

--- a/src/osyris/spatial/subdomain.py
+++ b/src/osyris/spatial/subdomain.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-import numpy as np
-from .. import Dataset
 import warnings
+
+import numpy as np
+
+from .. import Dataset
 
 
 def extract_sphere(dataset, radius, origin):

--- a/src/osyris/units/__init__.py
+++ b/src/osyris/units/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-# flake8: noqa
-
 from .library import UnitsLibrary
 from .units import units
+
+__all__ = ["UnitsLibrary", "units"]

--- a/src/osyris/units/__init__.py
+++ b/src/osyris/units/__init__.py
@@ -3,5 +3,5 @@
 
 # flake8: noqa
 
-from .units import units
 from .library import UnitsLibrary
+from .units import units

--- a/src/osyris/units/units.py
+++ b/src/osyris/units/units.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from pint import Quantity, UnitRegistry, Unit
+from pint import Quantity, Unit, UnitRegistry
+
 from .. import config
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-from common import arrayclose, arraytrue, arrayequal
-from osyris import Array, units
 from copy import copy, deepcopy
+
 import numpy as np
-from pint.errors import DimensionalityError
 import pytest
+from common import arrayclose, arrayequal, arraytrue
+from pint.errors import DimensionalityError
+
+from osyris import Array, units
 
 
 def test_constructor_ndarray():

--- a/test/test_datagroup.py
+++ b/test/test_datagroup.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-from common import arrayequal
-from osyris import Array, Datagroup
 from copy import copy, deepcopy
+
 import pytest
+from common import arrayequal
+
+from osyris import Array, Datagroup
 
 
 def test_datagroup_creation():

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-from common import arrayequal
-from osyris import Array, Datagroup, Dataset
 from copy import copy, deepcopy
+
+from common import arrayequal
+
+from osyris import Array, Datagroup, Dataset
 
 
 def test_dataset_creation():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Osyris contributors (https://github.com/osyris-project/osyris)
-from common import vectorclose, vectorequal, arrayequal, arrayclose
-from osyris import Array, Vector, units
 from copy import copy, deepcopy
+
 import numpy as np
 import pytest
+from common import arrayclose, arrayequal, vectorclose, vectorequal
+
+from osyris import Array, Vector, units
 
 
 def test_constructor_from_arrays():


### PR DESCRIPTION
- Until now, the package had to `__version__` attribute. We fix this here.
- We also add `isort` to the CI formatting to sort the imports.