### PR TITLE
Add more numpy methods to arrays

### DIFF
--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -9,6 +9,7 @@ from .base import Base
 from .tools import value_to_string
 
 APPLY_OP_TO_UNIT = ("multiply", "true_divide", "divide", "sqrt", "power", "reciprocal")
+NO_UNIT_IN_RESULT = ("argmin", "argmax", "argpartition", "argsort")
 
 
 def _binary_op(op, lhs, rhs, strict=True, **kwargs):
@@ -253,13 +254,13 @@ class Array(Base):
         result = func(*array_args, **self._extract_arrays_from_kwargs(kwargs))
 
         unit = None
-        if result.dtype in (int, float):
+        if getattr(result, "dtype", None) in (int, float):
             if func.__name__ in APPLY_OP_TO_UNIT:
                 unit = func(
                     *self._extract_units(args),
                     **{key: a for key, a in kwargs.items() if key != "out"},
                 ).units
-            else:
+            elif func.__name__ not in NO_UNIT_IN_RESULT:
                 unit = self.unit
 
         if "out" in kwargs:

--- a/src/osyris/core/base.py
+++ b/src/osyris/core/base.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
+from functools import partial
 
 import numpy as np
 
@@ -18,13 +19,10 @@ class Base:
 
     @property
     def label(self):
+        """
+        Return a label for the object with name and unit.
+        """
         return make_label(name=self.name, unit=self.unit)
-
-    def min(self):
-        return np.amin(self)
-
-    def max(self):
-        return np.amax(self)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         """
@@ -41,3 +39,8 @@ class Base:
         functions.
         """
         return self._wrap_numpy(func, *args, **kwargs)
+
+    def __getattr__(self, name):
+        if hasattr(np, name):
+            return partial(getattr(np, name), self)
+        raise AttributeError(f"No attribute named '{name}'")

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -817,3 +817,18 @@ def test_numpy_divide_with_float():
     result = np.divide(b, a)
     assert np.array_equal(result.values, expected)
     assert result.unit == units("1/m")
+
+
+def test_numpy_array_methods():
+    a = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
+    assert arrayequal(a.mean(), Array(values=3.0, unit="m"))
+    assert arrayclose(a.std(), Array(values=1.41421356, unit="m"))
+    assert arrayequal(a.sum(), Array(values=15.0, unit="m"))
+    assert arrayequal(a.prod(), Array(values=120.0, unit="m"))
+    assert arrayequal(a.cumsum(), Array(values=[1.0, 3.0, 6.0, 10.0, 15.0], unit="m"))
+    assert arrayequal(a.cumprod(), Array(values=[1.0, 2.0, 6.0, 24.0, 120.0], unit="m"))
+    assert arrayequal(a.min(), Array(values=1.0, unit="m"))
+    assert arrayequal(a.max(), Array(values=5.0, unit="m"))
+    assert arrayequal(a.argmin(), Array(values=0, unit="dimensionless"))
+    assert arrayequal(a.argmax(), Array(values=4, unit="dimensionless"))
+    assert arrayequal(a.ptp(), Array(values=4.0, unit="m"))


### PR DESCRIPTION
Support more `ndarray` methods including `mean, std, sum, prod, var, min, max, argmin, argmax, ptp, all, any, round, clip`.
This means that
```Py
from osyris import Array

a = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
a.mean()
```
now works and gives
```
'' Value: 3.0 [m] ()
```