### PR TITLE
Fix RHS operations when LHS is a pint quantity

### DIFF
--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -151,11 +151,17 @@ class Array(Base):
     def __iadd__(self, other):
         return _binary_op(np.add, self, other, out=self)
 
+    def __radd__(self, other):
+        return self + other
+
     def __sub__(self, other):
         return _binary_op(np.subtract, self, other)
 
     def __isub__(self, other):
         return _binary_op(np.subtract, self, other, out=self)
+
+    def __rsub__(self, other):
+        return -(self - other)
 
     def __mul__(self, other):
         return _binary_op(np.multiply, self, other, strict=False)

--- a/src/osyris/units/units.py
+++ b/src/osyris/units/units.py
@@ -26,4 +26,4 @@ units = Units()
 
 # Add compatibility for upcasting
 compat.upcast_type_map["osyris.core.array.Array"] = None
-compat.upcast_type_map["osyris.core.array.Vector"] = None
+compat.upcast_type_map["osyris.core.vector.Vector"] = None

--- a/src/osyris/units/units.py
+++ b/src/osyris/units/units.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from pint import Quantity, Unit, UnitRegistry
+from pint import compat
 
 from .. import config
 
@@ -23,3 +24,7 @@ class Units:
 
 
 units = Units()
+
+# Add compatibility for upcasting
+compat.upcast_type_map["osyris.core.array.Array"] = None
+compat.upcast_type_map["osyris.core.array.Vector"] = None

--- a/src/osyris/units/units.py
+++ b/src/osyris/units/units.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
-from pint import Quantity, Unit, UnitRegistry
-from pint import compat
+from pint import Quantity, Unit, UnitRegistry, compat
 
 from .. import config
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -103,6 +103,13 @@ def test_addition_quantity():
     assert arrayclose(a + b, expected)
 
 
+def test_addition_quantity_rhs():
+    a = 3.5 * units("m")
+    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
+    expected = Array(values=[4.5, 5.5, 6.5, 7.5, 8.5], unit="m")
+    assert arrayclose(a + b, expected)
+
+
 def test_addition_inplace():
     a = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
@@ -139,6 +146,13 @@ def test_subtraction_quantity():
     a = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
     b = 3.5 * units("m")
     expected = Array(values=[-2.5, -1.5, -0.5, 0.5, 1.5], unit="m")
+    assert arrayclose(a - b, expected)
+
+
+def test_subtraction_quantity_rhs():
+    a = 3.5 * units("m")
+    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
+    expected = Array(values=[2.5, 1.5, 0.5, -0.5, -1.5], unit="m")
     assert arrayclose(a - b, expected)
 
 
@@ -191,6 +205,13 @@ def test_multiplication_ndarray():
 def test_multiplication_quantity():
     a = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
     b = 3.5 * units("s")
+    expected = Array(values=[3.5, 7.0, 10.5, 14.0, 17.5], unit="m*s")
+    assert arrayclose(a * b, expected)
+
+
+def test_multiplication_quantity_rhs():
+    a = 3.5 * units("s")
+    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
     expected = Array(values=[3.5, 7.0, 10.5, 14.0, 17.5], unit="m*s")
     assert arrayclose(a * b, expected)
 
@@ -258,6 +279,13 @@ def test_division_quantity():
     a = Array(values=[0.0, 2.0, 4.0, 6.0, 200.0], unit="s")
     b = 2.0 * units("s")
     expected = Array(values=[0.0, 1.0, 2.0, 3.0, 100.0], unit="dimensionless")
+    assert arrayclose(a / b, expected)
+
+
+def test_division_quantity_rhs():
+    a = 2.0 * units("s")
+    b = Array(values=[1.0, 2.0, 4.0, 6.0, 200.0], unit="s")
+    expected = Array(values=[2.0, 1.0, 0.5, 1.0 / 3.0, 0.01], unit="dimensionless")
     assert arrayclose(a / b, expected)
 
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -78,6 +78,7 @@ def test_addition():
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     expected = Array(values=[7.0, 9.0, 11.0, 13.0, 15.0], unit="m")
     assert arrayclose(a + b, expected)
+    assert arrayclose(b + a, expected)
 
 
 def test_addition_conversion():
@@ -85,6 +86,8 @@ def test_addition_conversion():
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="cm")
     expected = Array(values=[1.06, 2.07, 3.08, 4.09, 5.1], unit="m")
     assert arrayclose(a + b, expected)
+    expected = Array(values=[106.0, 207.0, 308.0, 409.0, 510.0], unit="cm")
+    assert arrayclose(b + a, expected)
 
 
 def test_addition_bad_units():
@@ -101,13 +104,7 @@ def test_addition_quantity():
     b = 3.5 * units("m")
     expected = Array(values=[4.5, 5.5, 6.5, 7.5, 8.5], unit="m")
     assert arrayclose(a + b, expected)
-
-
-def test_addition_quantity_rhs():
-    a = 3.5 * units("m")
-    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
-    expected = Array(values=[4.5, 5.5, 6.5, 7.5, 8.5], unit="m")
-    assert arrayclose(a + b, expected)
+    assert arrayclose(b + a, expected)
 
 
 def test_addition_inplace():
@@ -131,6 +128,8 @@ def test_subtraction():
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     expected = Array(values=[5.0, 5.0, 5.0, 5.0, 5.0], unit="m")
     assert arrayclose(b - a, expected)
+    expected = Array(values=[-5.0, -5.0, -5.0, -5.0, -5.0], unit="m")
+    assert arrayclose(a - b, expected)
 
 
 def test_subtraction_bad_units():
@@ -147,13 +146,8 @@ def test_subtraction_quantity():
     b = 3.5 * units("m")
     expected = Array(values=[-2.5, -1.5, -0.5, 0.5, 1.5], unit="m")
     assert arrayclose(a - b, expected)
-
-
-def test_subtraction_quantity_rhs():
-    a = 3.5 * units("m")
-    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
     expected = Array(values=[2.5, 1.5, 0.5, -0.5, -1.5], unit="m")
-    assert arrayclose(a - b, expected)
+    assert arrayclose(b - a, expected)
 
 
 def test_subtraction_inplace():
@@ -177,6 +171,7 @@ def test_multiplication():
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     expected = Array(values=[6.0, 14.0, 24.0, 36.0, 50.0], unit="m*m")
     assert arrayclose(a * b, expected)
+    assert arrayclose(b * a, expected)
 
 
 def test_multiplication_conversion():
@@ -184,6 +179,8 @@ def test_multiplication_conversion():
     b = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="cm")
     expected = Array(values=[0.06, 0.14, 0.24, 0.36, 0.5], unit="m*m")
     assert arrayclose(a * b, expected)
+    expected = Array(values=[600.0, 1400.0, 2400.0, 3600.0, 5000.0], unit="cm*cm")
+    assert arrayclose(b * a, expected)
 
 
 def test_multiplication_float():
@@ -207,13 +204,7 @@ def test_multiplication_quantity():
     b = 3.5 * units("s")
     expected = Array(values=[3.5, 7.0, 10.5, 14.0, 17.5], unit="m*s")
     assert arrayclose(a * b, expected)
-
-
-def test_multiplication_quantity_rhs():
-    a = 3.5 * units("s")
-    b = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
-    expected = Array(values=[3.5, 7.0, 10.5, 14.0, 17.5], unit="m*s")
-    assert arrayclose(a * b, expected)
+    assert arrayclose(b * a, expected)
 
 
 def test_multiplication_inplace():
@@ -271,22 +262,19 @@ def test_division_ndarray():
         values=[1.0 / 5.0, 2.0 / 6.0, 3.0 / 7.0, 4.0 / 8.0, 5.0 / 9.0], unit="s"
     )
     assert arrayclose(a / b, expected)
-    # expected = Array(values=[3., 3. / 2., 1., 3. / 4., 3. / 5.], unit='1/s')
-    # assert arrayclose(b / a, expected)
+    expected = Array(
+        values=[5.0, 6.0 / 2.0, 7.0 / 3.0, 8.0 / 4.0, 9.0 / 5.0], unit="1/s"
+    )
+    assert arrayclose(b / a, expected)
 
 
 def test_division_quantity():
-    a = Array(values=[0.0, 2.0, 4.0, 6.0, 200.0], unit="s")
+    a = Array(values=[1.0, 2.0, 4.0, 6.0, 200.0], unit="s")
     b = 2.0 * units("s")
-    expected = Array(values=[0.0, 1.0, 2.0, 3.0, 100.0], unit="dimensionless")
+    expected = Array(values=[0.5, 1.0, 2.0, 3.0, 100.0], unit="dimensionless")
     assert arrayclose(a / b, expected)
-
-
-def test_division_quantity_rhs():
-    a = 2.0 * units("s")
-    b = Array(values=[1.0, 2.0, 4.0, 6.0, 200.0], unit="s")
     expected = Array(values=[2.0, 1.0, 0.5, 1.0 / 3.0, 0.01], unit="dimensionless")
-    assert arrayclose(a / b, expected)
+    assert arrayclose(b / a, expected)
 
 
 def test_division_inplace():
@@ -313,8 +301,6 @@ def test_division_ndarray_inplace():
     )
     a /= b
     assert arrayclose(a, expected)
-    # expected = Array(values=[3., 3. / 2., 1., 3. / 4., 3. / 5.], unit='1/s')
-    # assert arrayclose(b / a, expected)
 
 
 def test_division_quantity_inplace():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -87,8 +87,10 @@ def test_addition():
     y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
     v = Vector(x, y, z)
-    expected = Vector(x=x + x, y=y + y, z=z + z)
-    assert vectorequal(v + v, expected)
+    w = Vector(y, x, z)
+    expected = Vector(x=x + y, y=y + x, z=z + z)
+    assert vectorequal(v + w, expected)
+    assert vectorequal(w + v, expected)
 
 
 def test_addition_array():
@@ -98,6 +100,7 @@ def test_addition_array():
     v = Vector(x, y, z)
     expected = Vector(x=x + x, y=y + x, z=z + x)
     assert vectorequal(v + x, expected)
+    assert vectorequal(x + v, expected)
 
 
 def test_addition_quantity():
@@ -108,6 +111,7 @@ def test_addition_quantity():
     q = 3.5 * units("m")
     expected = Vector(x=x + q, y=y + q, z=z + q)
     assert vectorequal(v + q, expected)
+    assert vectorequal(q + v, expected)
 
 
 def test_addition_inplace():
@@ -147,8 +151,10 @@ def test_subtraction():
     y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
     v = Vector(x, y, z)
-    expected = Vector(x=x - x, y=y - y, z=z - z)
-    assert vectorequal(v - v, expected)
+    w = Vector(y, x, z)
+    expected = Vector(x=x - y, y=y - x, z=z - z)
+    assert vectorequal(v - w, expected)
+    assert vectorequal(w - v, -expected)
 
 
 def test_subtraction_array():
@@ -158,6 +164,7 @@ def test_subtraction_array():
     v = Vector(x, y, z)
     expected = Vector(x=x - x, y=y - x, z=z - x)
     assert vectorequal(v - x, expected)
+    assert vectorequal(x - v, -expected)
 
 
 def test_subtraction_quantity():
@@ -168,6 +175,7 @@ def test_subtraction_quantity():
     q = 3.5 * units("m")
     expected = Vector(x=x - q, y=y - q, z=z - q)
     assert vectorequal(v - q, expected)
+    assert vectorequal(q - v, -expected)
 
 
 def test_subtraction_inplace():
@@ -207,8 +215,10 @@ def test_multiplication():
     y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
     z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
     v = Vector(x, y, z)
-    expected = Vector(x=x * x, y=y * y, z=z * z)
-    assert vectorequal(v * v, expected)
+    w = Vector(z, x, y)
+    expected = Vector(x=x * z, y=y * x, z=z * y)
+    assert vectorequal(v * w, expected)
+    assert vectorequal(w * v, expected)
 
 
 def test_multiplication_array():
@@ -240,6 +250,7 @@ def test_multiplication_ndarray():
     a = np.arange(5.0)
     expected = Vector(x=x * a, y=y * a, z=z * a)
     assert vectorequal(v * a, expected)
+    assert vectorequal(a * v, expected)
 
 
 def test_multiplication_quantity():
@@ -250,6 +261,7 @@ def test_multiplication_quantity():
     q = 3.5 * units("m")
     expected = Vector(x=x * q, y=y * q, z=z * q)
     assert vectorequal(v * q, expected)
+    assert vectorequal(q * v, expected)
 
 
 def test_multiplication_inplace():
@@ -315,6 +327,8 @@ def test_division():
     v2 = Vector(w, y, w)
     expected = Vector(x=x / w, y=y / y, z=z / w)
     assert vectorequal(v1 / v2, expected)
+    expected = Vector(x=w / x, y=y / y, z=w / z)
+    assert vectorequal(v2 / v1, expected)
 
 
 def test_division_array():
@@ -324,6 +338,8 @@ def test_division_array():
     v = Vector(x, y, z)
     expected = Vector(x=x / x, y=y / x, z=z / x)
     assert vectorequal(v / x, expected)
+    expected = Vector(x=x / x, y=x / y, z=x / z)
+    assert vectorequal(x / v, expected)
 
 
 def test_division_float():
@@ -334,6 +350,8 @@ def test_division_float():
     f = 3.5
     expected = Vector(x=x / f, y=y / f, z=z / f)
     assert vectorequal(v / f, expected)
+    expected = Vector(x=f / x, y=f / y, z=f / z)
+    assert vectorequal(f / v, expected)
 
 
 def test_division_ndarray():
@@ -344,6 +362,8 @@ def test_division_ndarray():
     a = np.arange(3.0, 8.0)
     expected = Vector(x=x / a, y=y / a, z=z / a)
     assert vectorequal(v / a, expected)
+    expected = Vector(x=a / x, y=a / y, z=a / z)
+    assert vectorequal(a / v, expected)
 
 
 def test_division_quantity():
@@ -354,6 +374,8 @@ def test_division_quantity():
     q = 3.5 * units("m")
     expected = Vector(x=x / q, y=y / q, z=z / q)
     assert vectorequal(v / q, expected)
+    expected = Vector(x=q / x, y=q / y, z=q / z)
+    assert vectorequal(q / v, expected)
 
 
 def test_division_inplace():
@@ -410,36 +432,6 @@ def test_division_quantity_inplace():
     expected = Vector(x=x / q, y=y / q, z=z / q)
     v /= q
     assert vectorequal(v, expected)
-
-
-def test_rdivision_array():
-    x = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
-    y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
-    z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
-    v = Vector(x, y, z)
-    a = Array(values=[21.0, 22.0, 23.0, 24.0, 25.0], unit="s")
-    expected = Vector(x=a / x, y=a / y, z=a / z)
-    assert vectorclose(a / v, expected)
-
-
-def test_rdivision_float():
-    x = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
-    y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
-    z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
-    v = Vector(x, y, z)
-    f = 3.5
-    expected = Vector(x=f / x, y=f / y, z=f / z)
-    assert vectorclose(f / v, expected)
-
-
-# def test_division_ndarray():
-#     x = Array(values=[1., 2., 3., 4., 5.], unit='m')
-#     y = Array(values=[6., 7., 8., 9., 10.], unit='m')
-#     z = Array(values=[11., 12., 13., 14., 15.], unit='m')
-#     v = Vector(x, y, z)
-#     a = np.arange(3., 8.)
-#     expected = Vector(x=a / x, y=a / y, z=a / z)
-#     assert vectorclose(a / v, expected)
 
 
 def test_norm():
@@ -853,3 +845,14 @@ def test_numpy_binary():
     assert np.allclose(result.y.values, exp_y)
     assert np.allclose(result.z.values, exp_z)
     assert result.unit == units("m")
+
+
+def test_numpy_vstack():
+    x = Array(values=[1.0, 2.0, 3.0, 4.0, 5.0], unit="m")
+    y = Array(values=[6.0, 7.0, 8.0, 9.0, 10.0], unit="m")
+    z = Array(values=[11.0, 12.0, 13.0, 14.0, 15.0], unit="m")
+    v = Vector(x, y, z)
+    w = Vector(y, x, z)
+    result = np.vstack([v, w])
+    assert vectorequal(result[0], v)
+    assert vectorequal(result[1], w)


### PR DESCRIPTION
```Py
import osyris as oo

a = oo.Array(values=[1.0, 5.0], unit="m")
b = 3.5 * oo.units("m")

a + b
```
works, but `b + a` used to fail.

This PR fixes this.

Fixes #141 