### PR TITLE
Remove copyright year statement at the top of every file

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 name: Build Osyris
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Osyris contributors
+Copyright (c) 2025, Osyris contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, src)
 # -- Project information -----------------------------------------------------
 
 project = "osyris"
-copyright = "2024, Osyris contributors"
+copyright = "2025, Osyris contributors"
 author = "Neil Vaytet"
 
 # -- General configuration ---------------------------------------------------

--- a/src/osyris/__init__.py
+++ b/src/osyris/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 """Osyris: A Python package for the analysis of astrophysical simulations
 

--- a/src/osyris/config/__init__.py
+++ b/src/osyris/config/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 # Import the config from "/home/user/.osyris/conf.py if it exists.
 # If it doesn't, try to create one by copying the default from the source.

--- a/src/osyris/config/defaults.py
+++ b/src/osyris/config/defaults.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 """
 Define default values so that you don't have to specify them every time.
 """

--- a/src/osyris/core/__init__.py
+++ b/src/osyris/core/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 """ Core data structures of Osyris
 

--- a/src/osyris/core/array.py
+++ b/src/osyris/core/array.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 from pint import Quantity
 from pint.errors import DimensionalityError

--- a/src/osyris/core/base.py
+++ b/src/osyris/core/base.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from functools import partial
 
 import numpy as np

--- a/src/osyris/core/datagroup.py
+++ b/src/osyris/core/datagroup.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 
 from .layer import Layer

--- a/src/osyris/core/dataset.py
+++ b/src/osyris/core/dataset.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 
 from .. import config

--- a/src/osyris/core/layer.py
+++ b/src/osyris/core/layer.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from collections.abc import Iterable
 from typing import Dict, Optional, Union
 

--- a/src/osyris/core/plot.py
+++ b/src/osyris/core/plot.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 
 class Plot:

--- a/src/osyris/core/tools.py
+++ b/src/osyris/core/tools.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
 

--- a/src/osyris/core/vector.py
+++ b/src/osyris/core/vector.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 from pint import Quantity
 

--- a/src/osyris/io/__init__.py
+++ b/src/osyris/io/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from . import utils
 from .loader import Loader

--- a/src/osyris/io/amr.py
+++ b/src/osyris/io/amr.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import numpy as np
 
 from . import utils

--- a/src/osyris/io/grav.py
+++ b/src/osyris/io/grav.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import os
 
 from . import utils

--- a/src/osyris/io/hilbert.py
+++ b/src/osyris/io/hilbert.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
 

--- a/src/osyris/io/hydro.py
+++ b/src/osyris/io/hydro.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import os
 
 import numpy as np

--- a/src/osyris/io/loader.py
+++ b/src/osyris/io/loader.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import os
 

--- a/src/osyris/io/part.py
+++ b/src/osyris/io/part.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import os
 
 import numpy as np

--- a/src/osyris/io/ramses.py
+++ b/src/osyris/io/ramses.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from .. import config
 from ..core import Dataset
 from .loader import Loader

--- a/src/osyris/io/reader.py
+++ b/src/osyris/io/reader.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
 

--- a/src/osyris/io/rt.py
+++ b/src/osyris/io/rt.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 import os
 
 import numpy as np

--- a/src/osyris/io/sink.py
+++ b/src/osyris/io/sink.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import os
 

--- a/src/osyris/io/utils.py
+++ b/src/osyris/io/utils.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import glob
 import os

--- a/src/osyris/plot/__init__.py
+++ b/src/osyris/plot/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from .hist1d import hist1d
 from .hist2d import hist2d

--- a/src/osyris/plot/direction.py
+++ b/src/osyris/plot/direction.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
 

--- a/src/osyris/plot/hist1d.py
+++ b/src/osyris/plot/hist1d.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from typing import Iterable, Union
 

--- a/src/osyris/plot/hist2d.py
+++ b/src/osyris/plot/hist2d.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from typing import Iterable, Literal, Union
 

--- a/src/osyris/plot/map.py
+++ b/src/osyris/plot/map.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from typing import Union
 

--- a/src/osyris/plot/parser.py
+++ b/src/osyris/plot/parser.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 

--- a/src/osyris/plot/plot.py
+++ b/src/osyris/plot/plot.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from typing import Union
 

--- a/src/osyris/plot/render.py
+++ b/src/osyris/plot/render.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import matplotlib.pyplot as plt
 

--- a/src/osyris/plot/scatter.py
+++ b/src/osyris/plot/scatter.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from typing import Union
 

--- a/src/osyris/plot/wrappers.py
+++ b/src/osyris/plot/wrappers.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import io
 from contextlib import nullcontext, redirect_stderr

--- a/src/osyris/spatial/__init__.py
+++ b/src/osyris/spatial/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from .subdomain import extract_box, extract_sphere
 

--- a/src/osyris/spatial/subdomain.py
+++ b/src/osyris/spatial/subdomain.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import warnings
 

--- a/src/osyris/units/__init__.py
+++ b/src/osyris/units/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from .library import UnitsLibrary
 from .units import units

--- a/src/osyris/units/library.py
+++ b/src/osyris/units/library.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import re
 

--- a/src/osyris/units/units.py
+++ b/src/osyris/units/units.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 from pint import Quantity, Unit, UnitRegistry, compat
 

--- a/test/common.py
+++ b/test/common.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 import numpy as np
 

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from copy import copy, deepcopy
 
 import numpy as np

--- a/test/test_datagroup.py
+++ b/test/test_datagroup.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from copy import copy, deepcopy
 
 import numpy as np

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from copy import copy, deepcopy
 
 from common import arrayequal

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 
 
 def test_star_import_all():

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Osyris contributors (https://github.com/osyris-project/osyris)
 from copy import copy, deepcopy
 
 import numpy as np


### PR DESCRIPTION
It seems having the copyright and year in every file is not needed if everything is under version control in git.
See e.g. https://aboutcode.org/2023/update-copyright-each-new-year/#:~:text=No%2C%20but%20a%20copyright%20statement,in%20their%20project's%20copyright%20notices.

It's annoying to have to change this all the time.
So we remove them.