### PR TITLE
Add support for bisection decomposition

### DIFF
--- a/src/osyris/io/amr.py
+++ b/src/osyris/io/amr.py
@@ -127,12 +127,14 @@ class AmrReader(Reader):
         # Determine bound key precision
         self.offsets["i"] += 5
         self.offsets["s"] += 128
-        if(info["ordering type"] == "bisection"):
-            nbinodes = int(2**(np.ceil(np.log(float(info["ncpu"]))/np.log(2.0))+1)-1)
-            self.offsets["i"] += 3*nbinodes
-            self.offsets["d"] += nbinodes+2*info["ncpu"]*info["ndim"]
+        if info["ordering type"] == "bisection":
+            nbinodes = int(
+                2 ** (np.ceil(np.log(float(info["ncpu"])) / np.log(2.0)) + 1) - 1
+            )
+            self.offsets["i"] += 3 * nbinodes
+            self.offsets["d"] += nbinodes + 2 * info["ncpu"] * info["ndim"]
             self.offsets["n"] += 5
-            key_size=0
+            key_size = 0
         else:
             [key_size] = utils.read_binary_data(
                 fmt="i",


### PR DESCRIPTION
see https://github.com/ramses-organisation/ramses/pull/220

This PR allows to read RAMSES outputs with the bisection decomposition instead of the Hilbert one